### PR TITLE
Param grid opt params

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ This can be done by running `pip install .` from the `src/` directory.
 ### Running tests
 
 Unit tests for this project can be run using `pytest .` from the main directory.
+

--- a/src/python/qeopenfermion/_io_test.py
+++ b/src/python/qeopenfermion/_io_test.py
@@ -111,7 +111,7 @@ class TestQubitOperator(unittest.TestCase):
 
     def test_save_parameter_grid_evaluation(self):
         # Given
-        ansatz = {'ansatz_type': 'singlet UCCSD', 'ansatz_module': 'zquantum.qaoa.ansatz', 'ansatz_func': 'build_qaoa_circuit', 'ansatz_grad_func': 'build_qaoa_circuit_grads', 'supports_simple_shift_rule': False, 'ansatz_kwargs': {'hamiltonians': [{'schema': 'zapata-v1-qubit_op', 'terms': [{'pauli_ops': [], 'coefficient': {'real': 0.5}}, {'pauli_ops': [{'qubit': 1, 'op': 'Z'}], 'coefficient': {'real': 0.5}}]}, {'schema': 'zapata-v1-qubit_op', 'terms': [{'pauli_ops': [{'qubit': 0, 'op': 'X'}], 'coefficient': {'real': 1.0}}, {'pauli_ops': [{'qubit': 1, 'op': 'X'}], 'coefficient': {'real': 1.0}}]}]}, 'n_params': [2]}
+        ansatz = {'ansatz_module': 'zquantum.core.interfaces.mock_objects', 'ansatz_func': 'mock_ansatz', 'ansatz_kwargs': {}, 'n_params': [2]}
         grid = build_uniform_param_grid(ansatz, 1, 0, np.pi, np.pi/10)
         backend = create_object({'module_name': 'zquantum.core.interfaces.mock_objects', 'function_name': 'MockQuantumSimulator'})
         op = QubitOperator('0.5 [] + 0.5 [Z1]')

--- a/src/python/qeopenfermion/_io_test.py
+++ b/src/python/qeopenfermion/_io_test.py
@@ -6,7 +6,7 @@ from openfermion import (
     QubitOperator, InteractionOperator, FermionOperator, IsingOperator,
     get_interaction_operator, hermitian_conjugated
 )
-from zquantum.core.circuit import build_uniform_param_grid
+from zquantum.core.circuit import build_uniform_param_grid, save_circuit_template_params
 from zquantum.core.utils import create_object
 from ._utils import evaluate_operator_for_parameter_grid
 from ._io import (
@@ -115,11 +115,12 @@ class TestQubitOperator(unittest.TestCase):
         grid = build_uniform_param_grid(ansatz, 1, 0, np.pi, np.pi/10)
         backend = create_object({'module_name': 'zquantum.core.interfaces.mock_objects', 'function_name': 'MockQuantumSimulator'})
         op = QubitOperator('0.5 [] + 0.5 [Z1]')
-        parameter_grid_evaluation = evaluate_operator_for_parameter_grid(ansatz, grid, backend, op)
+        parameter_grid_evaluation, optimal_parameters = evaluate_operator_for_parameter_grid(ansatz, grid, backend, op)
         # When
         save_parameter_grid_evaluation(parameter_grid_evaluation, "parameter-grid-evaluation.json")
+        save_circuit_template_params(optimal_parameters, "optimal-parameters.json")
         # Then 
         # TODO
 
     def tearDown(self):
-        subprocess.run(["rm", "parameter-grid-evaluation.json"])
+        subprocess.run(["rm", "parameter-grid-evaluation.json", "optimal-parameters.json"])

--- a/src/python/qeopenfermion/_utils.py
+++ b/src/python/qeopenfermion/_utils.py
@@ -232,7 +232,10 @@ def evaluate_operator_for_parameter_grid(ansatz, grid, backend, operator,
 	Returns:
 		value_estimate (zquantum.core.utils.ValueEstimate): stores the value of the expectation and its
 			 precision
+		optimal_parameters (numpy array): the ansatz parameters representing the ansatz parameters 
+			resulting in the best minimum evaluation
 	"""
+	min_value_estimate = None
 	parameter_grid_evaluation = []
 	for last_layer_params in grid.params_list:
         # Build the ansatz circuit
@@ -244,8 +247,16 @@ def evaluate_operator_for_parameter_grid(ansatz, grid, backend, operator,
 		expectation_values = backend.get_expectation_values(circuit, operator)
 		value_estimate = ValueEstimate(sum(expectation_values.values))
 		parameter_grid_evaluation.append({'value': value_estimate, 'parameter1': last_layer_params[0], 'parameter2': last_layer_params[1]})
+
+		if min_value_estimate == None:
+			min_value_estimate = value_estimate
+			optimal_parameters = params
+		elif value_estimate.value < min_value_estimate.value:
+			min_value_estimate = value_estimate
+			optimal_parameters = params
 		
-	return parameter_grid_evaluation
+	return parameter_grid_evaluation, optimal_parameters
+
 
 
 def reverse_qubit_order(qubit_operator:QubitOperator, n_qubits:Optional[int]=None):
@@ -319,3 +330,4 @@ def change_operator_type(operator, operatorType):
 		new_operator += operatorType(tuple(op), operator.terms[op])
 	
 	return new_operator
+

--- a/src/python/qeopenfermion/_utils.py
+++ b/src/python/qeopenfermion/_utils.py
@@ -233,7 +233,8 @@ def evaluate_operator_for_parameter_grid(ansatz, grid, backend, operator,
 		value_estimate (zquantum.core.utils.ValueEstimate): stores the value of the expectation and its
 			 precision
 		optimal_parameters (numpy array): the ansatz parameters representing the ansatz parameters 
-			resulting in the best minimum evaluation
+			resulting in the best minimum evaluation. If multiple sets of parameters evaluate to the same value, 
+			the first set of parameters is chosen as the optimal.
 	"""
 	min_value_estimate = None
 	parameter_grid_evaluation = []

--- a/src/python/qeopenfermion/_utils_test.py
+++ b/src/python/qeopenfermion/_utils_test.py
@@ -95,7 +95,7 @@ class TestQubitOperator(unittest.TestCase):
 
     def test_evaluate_operator_for_parameter_grid(self):
         # Given
-        ansatz = {'ansatz_type': 'singlet UCCSD', 'ansatz_module': 'zquantum.qaoa.ansatz', 'ansatz_func': 'build_qaoa_circuit', 'ansatz_grad_func': 'build_qaoa_circuit_grads', 'supports_simple_shift_rule': False, 'ansatz_kwargs': {'hamiltonians': [{'schema': 'zapata-v1-qubit_op', 'terms': [{'pauli_ops': [], 'coefficient': {'real': 0.5}}, {'pauli_ops': [{'qubit': 1, 'op': 'Z'}], 'coefficient': {'real': 0.5}}]}, {'schema': 'zapata-v1-qubit_op', 'terms': [{'pauli_ops': [{'qubit': 0, 'op': 'X'}], 'coefficient': {'real': 1.0}}, {'pauli_ops': [{'qubit': 1, 'op': 'X'}], 'coefficient': {'real': 1.0}}]}]}, 'n_params': [2]}
+        ansatz = {'ansatz_module': 'zquantum.core.interfaces.mock_objects', 'ansatz_func': 'mock_ansatz', 'ansatz_kwargs': {}, 'n_params': [2]}
         grid = build_uniform_param_grid(ansatz, 1, 0, np.pi, np.pi/10)
         backend = create_object({'module_name': 'zquantum.core.interfaces.mock_objects', 'function_name': 'MockQuantumSimulator'})
         op = QubitOperator('0.5 [] + 0.5 [Z1]')

--- a/src/python/qeopenfermion/_utils_test.py
+++ b/src/python/qeopenfermion/_utils_test.py
@@ -99,8 +99,9 @@ class TestQubitOperator(unittest.TestCase):
         grid = build_uniform_param_grid(ansatz, 1, 0, np.pi, np.pi/10)
         backend = create_object({'module_name': 'zquantum.core.interfaces.mock_objects', 'function_name': 'MockQuantumSimulator'})
         op = QubitOperator('0.5 [] + 0.5 [Z1]')
+        previous_layer_parameters = [1, 1]
         # When
-        parameter_grid_evaluation = evaluate_operator_for_parameter_grid(ansatz, grid, backend, op)
+        parameter_grid_evaluation, optimal_parameters = evaluate_operator_for_parameter_grid(ansatz, grid, backend, op, previous_layer_params=previous_layer_parameters)
         # Then (for brevity, only check first and last evaluations)
         self.assertIsInstance(parameter_grid_evaluation[0]['value'].value, float)
         self.assertEqual(parameter_grid_evaluation[0]['parameter1'], 0)
@@ -108,6 +109,10 @@ class TestQubitOperator(unittest.TestCase):
         self.assertIsInstance(parameter_grid_evaluation[99]['value'].value, float)
         self.assertEqual(parameter_grid_evaluation[99]['parameter1'], np.pi-np.pi/10)
         self.assertEqual(parameter_grid_evaluation[99]['parameter2'], np.pi-np.pi/10)
+        
+        self.assertEqual(len(optimal_parameters), 4)
+        self.assertEqual(optimal_parameters[0], 1)
+        self.assertEqual(optimal_parameters[1], 1)
 
     def test_reverse_qubit_order(self):
         # Given

--- a/templates/evaluation.yaml
+++ b/templates/evaluation.yaml
@@ -83,6 +83,9 @@ spec:
         path: /app/grid.json
       - name: operator
         path: /app/operator.json
+      - name: previous-parameters
+        optional: True
+        path: /app/previous_parameters.json
       - name: main-script
         path: /app/main_script.sh
         raw:
@@ -95,15 +98,21 @@ spec:
         path: /app/python_script.py
         raw:
           data: |
+            import os
             from qeopenfermion import evaluate_operator_for_parameter_grid, save_parameter_grid_evaluation, load_qubit_operator
-            from zquantum.core.circuit import load_circuit_template, load_parameter_grid, save_circuit_template_params
+            from zquantum.core.circuit import load_circuit_template, load_parameter_grid, load_circuit_template_params, save_circuit_template_params
             from zquantum.core.utils import create_object
 
             ansatz = load_circuit_template("ansatz.json")
             grid = load_parameter_grid("grid.json")
             backend = create_object({{inputs.parameters.backend-specs}})
             operator = load_qubit_operator("operator.json")
-            previous_layer_parameters = {{inputs.parameters.previous-layer-parameters}}
+
+            if(os.path.isfile('previous_parameters.json')):
+              previous_layer_parameters = load_circuit_template_params('previous_parameters.json')
+            else:
+              previous_layer_parameters = {{inputs.parameters.previous-layer-parameters}}
+              
             parameter_grid_evaluation, optimal_parameters = evaluate_operator_for_parameter_grid(ansatz,
               grid, backend, operator, previous_layer_params=previous_layer_parameters)
 

--- a/templates/evaluation.yaml
+++ b/templates/evaluation.yaml
@@ -96,7 +96,7 @@ spec:
         raw:
           data: |
             from qeopenfermion import evaluate_operator_for_parameter_grid, save_parameter_grid_evaluation, load_qubit_operator
-            from zquantum.core.circuit import load_circuit_template, load_parameter_grid
+            from zquantum.core.circuit import load_circuit_template, load_parameter_grid, save_circuit_template_params
             from zquantum.core.utils import create_object
 
             ansatz = load_circuit_template("ansatz.json")
@@ -104,12 +104,15 @@ spec:
             backend = create_object({{inputs.parameters.backend-specs}})
             operator = load_qubit_operator("operator.json")
             previous_layer_parameters = {{inputs.parameters.previous-layer-parameters}}
-            parameter_grid_evaluation = evaluate_operator_for_parameter_grid(ansatz,
+            parameter_grid_evaluation, optimal_parameters = evaluate_operator_for_parameter_grid(ansatz,
               grid, backend, operator, previous_layer_params=previous_layer_parameters)
 
             save_parameter_grid_evaluation(parameter_grid_evaluation, "parameter-grid-evaluation.json")
+            save_circuit_template_params(optimal_parameters, '/app/optimal-parameters.json')
     outputs:
       artifacts:
       - name: parameter-grid-evaluation
         path: /app/parameter-grid-evaluation.json
+      - name: optimal-parameters
+        path: /app/optimal-parameters.json
 


### PR DESCRIPTION
Function for `evaluate_operator_for_parameter_grid` now returns the ansatz parameters representing the circuit parameters leading to the lowest measured expectation value of the operator. 

Useful for doing workflows with grid search.