### PR TITLE
Get fermion operator before applying Bravyi-Kitaev transform. 

### DIFF
--- a/templates/transforms.yaml
+++ b/templates/transforms.yaml
@@ -17,13 +17,14 @@ spec:
           data: |
             import os
             from qeopenfermion import load_interaction_operator, save_qubit_operator
-            from openfermion import jordan_wigner, bravyi_kitaev
+            from openfermion import jordan_wigner, bravyi_kitaev, get_fermion_operator
 
             input_op = load_interaction_operator('input-op.json')
 
             if '{{inputs.parameters.transformation}}' == 'Jordan-Wigner':
               transformation = jordan_wigner
             elif '{{inputs.parameters.transformation}}' == 'Bravyi-Kitaev':
+              input_op = get_fermion_operator(input_op)
               transformation = bravyi_kitaev
             else:
               raise RuntimeException('Unrecognized transformation {{inputs.parameters.transformation}}')


### PR DESCRIPTION
The Bravyi-Kitaev transform can only be applied to `FermionOperator`s and `MajoranaOperator`s. Otherwise, [an exception](https://github.com/quantumlib/OpenFermion/blob/master/src/openfermion/transforms/_bravyi_kitaev.py#L47) is thrown. 

In this PR, we turn the `InteractionOperator` into a `FermionOperator` when the Bravyi-Kitaev transform is used. 