### PR TITLE
Diagonalop

### DIFF
--- a/templates/operators.yaml
+++ b/templates/operators.yaml
@@ -22,3 +22,30 @@ spec:
       artifacts:
       - name: number-op
         path: /app/number-op.json
+
+  # get diagonal component
+  - name: get-diagonal-component
+    parent: generic-task
+    inputs:
+      parameters:
+      - name: command
+        value: python3 main_script.py
+      artifacts:
+      - name: interaction-op
+        path: /app/interaction_op.json
+      - name: main-script
+        path: /app/main_script.py
+        raw:
+          data: |
+            from qeopenfermion import (get_diagonal_component, save_interaction_operator, 
+                                       load_interaction_operator)
+            interaction_op = load_interaction_operator('interaction_op.json')
+            diagonal_op, remainder_op = get_diagonal_component(interaction_op)
+            save_interaction_operator(diagonal_op, 'diagonal_op.json')
+            save_interaction_operator(remainder_op, 'remainder_op.json')
+    outputs:
+      artifacts:
+      - name: diagonal-op
+        path: /app/diagonal_op.json
+      - name: remainder-op
+        path: /app/remainder_op.json


### PR DESCRIPTION
Added the following functions:
- Function to extract the diagonal part of an interaction operator or a polynomial tensor operator. This is used in AAVQE calculations and Orbital frames.
- Function to transform a fermion operator in a polynomial tensor.