### PR TITLE
Qubitop interpolation

### DIFF
--- a/templates/operators.yaml
+++ b/templates/operators.yaml
@@ -68,7 +68,7 @@ spec:
         path: /app/main_script.py
         raw:
           data: |
-            from zquantum.core.qubitoperator import load_qubit_operator, save_qubit_operator
+            from qeopenfermion import load_qubit_operator, save_qubit_operator
             reference_qubit_operator = load_qubit_operator('reference-qubit-operator.json')
             target_qubit_operator = load_qubit_operator('target-qubit-operator.json')
             epsilon = {{inputs.parameters.epsilon}}

--- a/templates/operators.yaml
+++ b/templates/operators.yaml
@@ -49,3 +49,34 @@ spec:
         path: /app/diagonal_op.json
       - name: remainder-op
         path: /app/remainder_op.json
+
+  # get interpolation between two qubit operators
+  - name: interpolate-qubit-operators
+    parent: generic-task
+    inputs:
+      parameters:
+      - name: epsilon
+        default: 0.5
+      - name: command
+        value: python3 main_script.py
+      artifacts:
+      - name: reference-qubit-operator
+        path: /app/reference-qubit-operator.json
+      - name: target-qubit-operator
+        path: /app/target-qubit-operator.json
+      - name: main-script
+        path: /app/main_script.py
+        raw:
+          data: |
+            from zquantum.core.qubitoperator import load_qubit_operator, save_qubit_operator
+            reference_qubit_operator = load_qubit_operator('reference-qubit-operator.json')
+            target_qubit_operator = load_qubit_operator('target-qubit-operator.json')
+            epsilon = {{inputs.parameters.epsilon}}
+            if epsilon > 1.0 or epsilon < 0.0:
+              raise ValueError("epsilon must be in the range [0.0, 1.0]")
+            output_qubit_operator = epsilon * target_qubit_operator + (1.0 - epsilon) * reference_qubit_operator
+            save_qubit_operator(output_qubit_operator, 'output_qubit_operator.json')
+    outputs:
+      artifacts:
+      - name: output-qubit-operator
+        path: /app/output_qubit_operator.json


### PR DESCRIPTION
Added task template to interpolate two qubit operators. This feature is used for carrying out adiabatic assisted VQE calculations.